### PR TITLE
Add Chinese language option to the system

### DIFF
--- a/flowsettings.py
+++ b/flowsettings.py
@@ -262,7 +262,7 @@ SETTINGS_REASONING = {
     "lang": {
         "name": "Language",
         "value": "en",
-        "choices": [("English", "en"), ("Japanese", "ja"), ("Vietnamese", "vi")],
+        "choices": [("English", "en"), ("Japanese", "ja"), ("Vietnamese", "vi"), ("Chinese", "cn")],
         "component": "dropdown",
     },
     "max_context_length": {

--- a/libs/ktem/ktem/utils/lang.py
+++ b/libs/ktem/ktem/utils/lang.py
@@ -1,1 +1,1 @@
-SUPPORTED_LANGUAGE_MAP = {"en": "English", "ja": "Japanese", "vi": "Vietnamese"}
+SUPPORTED_LANGUAGE_MAP = {"en": "English", "ja": "Japanese", "vi": "Vietnamese", "cn": "Chinese"}


### PR DESCRIPTION
Add Chinese language option to the system.

* **flowsettings.py**
  - Add "Chinese" to the language choices in the "lang" setting.

* **libs/ktem/ktem/utils/lang.py**
  - Add "cn" for Chinese to the `SUPPORTED_LANGUAGE_MAP`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/walkingzzzy/kotaemon?shareId=5670dbae-4af0-422a-8013-3fd5d57505d7).